### PR TITLE
feat: settings with new SettingsOption UDT

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # App Config
-APP_NAME="Gaming Leaderboard"
-APP_VERSION="0.0.4"
+APP_NAME="TBP Consumer API"
+APP_VERSION="0.1.0"
 APP_URL="0.0.0.0"
 APP_PORT="8000"
 APP_TLS_ENABLED="false"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "twitch-extension-api"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/current_schema.json
+++ b/current_schema.json
@@ -9,12 +9,12 @@
         ],
         [
           "occupation",
-          "text",
+          "frozen<settingoptions>",
           false
         ],
         [
           "pronouns",
-          "text",
+          "frozen<settingoptions>",
           false
         ],
         [
@@ -39,22 +39,22 @@
         ]
       ],
       "field_names": [
-        "locale",
+        "pronouns",
         "updated_at",
-        "username",
         "occupation",
         "timezone",
-        "pronouns",
-        "user_id"
+        "locale",
+        "user_id",
+        "username"
       ],
       "types_by_name": {
-        "user_id": "int",
         "updated_at": "timestamp",
+        "user_id": "int",
+        "pronouns": "frozen<settingoptions>",
         "username": "text",
-        "pronouns": "text",
         "locale": "text",
         "timezone": "text",
-        "occupation": "text"
+        "occupation": "frozen<settingoptions>"
       },
       "type_name": "",
       "table_name": "",
@@ -109,22 +109,22 @@
         ]
       ],
       "field_names": [
-        "user_id",
-        "message_id",
         "content",
-        "username",
         "color",
         "channel_id",
-        "sent_at"
+        "message_id",
+        "sent_at",
+        "user_id",
+        "username"
       ],
       "types_by_name": {
         "user_id": "int",
         "username": "text",
-        "message_id": "uuid",
-        "channel_id": "int",
         "color": "text",
+        "sent_at": "timestamp",
+        "channel_id": "int",
         "content": "text",
-        "sent_at": "timestamp"
+        "message_id": "uuid"
       },
       "type_name": "",
       "table_name": "",
@@ -146,79 +146,85 @@
       "table_options": null
     }
   },
-  "udts": {},
-  "materialized_views": {
-    "settings_by_username": {
+  "udts": {
+    "settingoptions": {
       "fields": [
         [
-          "locale",
+          "name",
           "text",
           false
         ],
         [
-          "occupation",
+          "slug",
           "text",
           false
         ],
         [
-          "pronouns",
-          "text",
-          false
-        ],
-        [
-          "timezone",
-          "text",
-          false
-        ],
-        [
-          "updated_at",
-          "timestamp",
-          false
-        ],
-        [
-          "user_id",
-          "int",
-          false
-        ],
-        [
-          "username",
+          "translation_key",
           "text",
           false
         ]
       ],
       "field_names": [
-        "locale",
-        "occupation",
-        "timezone",
-        "user_id",
-        "username",
-        "pronouns",
-        "updated_at"
+        "translation_key",
+        "name",
+        "slug"
       ],
       "types_by_name": {
-        "locale": "text",
-        "updated_at": "timestamp",
-        "occupation": "text",
-        "timezone": "text",
-        "user_id": "int",
-        "pronouns": "text",
-        "username": "text"
+        "name": "text",
+        "translation_key": "text",
+        "slug": "text"
       },
       "type_name": "",
       "table_name": "",
       "base_table": "",
-      "partition_keys": [
-        "username"
-      ],
-      "clustering_keys": [
-        "updated_at",
-        "user_id"
-      ],
+      "partition_keys": [],
+      "clustering_keys": [],
       "static_columns": [],
       "global_secondary_indexes": [],
       "local_secondary_indexes": [],
       "table_options": null
     },
+    "setting_options": {
+      "fields": [
+        [
+          "name",
+          "text",
+          false
+        ],
+        [
+          "slug",
+          "text",
+          false
+        ],
+        [
+          "translation_key",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "translation_key",
+        "slug",
+        "name"
+      ],
+      "types_by_name": {
+        "translation_key": "text",
+        "name": "text",
+        "slug": "text"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    }
+  },
+  "materialized_views": {
     "messages_username_idx_index": {
       "fields": [
         [
@@ -243,16 +249,16 @@
         ]
       ],
       "field_names": [
-        "idx_token",
-        "sent_at",
         "channel_id",
-        "username"
+        "idx_token",
+        "username",
+        "sent_at"
       ],
       "types_by_name": {
         "channel_id": "int",
-        "username": "text",
+        "idx_token": "bigint",
         "sent_at": "timestamp",
-        "idx_token": "bigint"
+        "username": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -264,6 +270,77 @@
         "channel_id",
         "idx_token",
         "sent_at"
+      ],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "settings_by_username": {
+      "fields": [
+        [
+          "locale",
+          "text",
+          false
+        ],
+        [
+          "occupation",
+          "frozen<settingoptions>",
+          false
+        ],
+        [
+          "pronouns",
+          "frozen<settingoptions>",
+          false
+        ],
+        [
+          "timezone",
+          "text",
+          false
+        ],
+        [
+          "updated_at",
+          "timestamp",
+          false
+        ],
+        [
+          "user_id",
+          "int",
+          false
+        ],
+        [
+          "username",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "updated_at",
+        "locale",
+        "username",
+        "timezone",
+        "occupation",
+        "user_id",
+        "pronouns"
+      ],
+      "types_by_name": {
+        "locale": "text",
+        "pronouns": "frozen<settingoptions>",
+        "occupation": "frozen<settingoptions>",
+        "timezone": "text",
+        "updated_at": "timestamp",
+        "user_id": "int",
+        "username": "text"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "username"
+      ],
+      "clustering_keys": [
+        "updated_at",
+        "user_id"
       ],
       "static_columns": [],
       "global_secondary_indexes": [],

--- a/src/http/settings_controller.rs
+++ b/src/http/settings_controller.rs
@@ -34,13 +34,6 @@ pub async fn put_settings(
 ) -> anyhow::Result<impl Responder, SomeError> {
   let settings = message.into_inner();
 
-  let pronouns = settings.pronouns.clone().unwrap().to_lowercase();
-  if !AVAILABLE_PRONOUNS.contains(&pronouns.as_str()) {
-    return Ok(HttpResponse::UnprocessableEntity().json(json!({
-        "message": "pronoun not listed"
-    })));
-  }
-
   settings.insert().execute(&data.database).await?;
 
   Ok(HttpResponse::Ok().json(json!(settings)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,30 +22,36 @@ async fn main() -> std::io::Result<()> {
   let tls_enabled = app_data.config.tls.enabled;
   debug!("Web Server Online!");
 
-  // TLS setup.
-  rustls::crypto::aws_lc_rs::default_provider()
-    .install_default()
-    .unwrap();
+  let tls_config = if tls_enabled {
+    // TLS setup.
+    rustls::crypto::aws_lc_rs::default_provider()
+      .install_default()
+      .unwrap();
 
-  let mut certs_file = BufReader::new(File::open(app_data.config.tls.cert.clone()).unwrap());
-  let mut key_file = BufReader::new(File::open(app_data.config.tls.key.clone()).unwrap());
+    let mut certs_file = BufReader::new(File::open(app_data.config.tls.cert.clone()).unwrap());
+    let mut key_file = BufReader::new(File::open(app_data.config.tls.key.clone()).unwrap());
 
-  // load TLS certs and key
-  // to create a self-signed temporary cert for testing:
-  // `openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost'`
-  let tls_certs = rustls_pemfile::certs(&mut certs_file)
-    .collect::<Result<Vec<_>, _>>()
-    .unwrap();
-  let tls_key = rustls_pemfile::pkcs8_private_keys(&mut key_file)
-    .next()
-    .unwrap()
-    .unwrap();
+    // load TLS certs and key
+    // to create a self-signed temporary cert for testing:
+    // `openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost'`
+    let tls_certs = rustls_pemfile::certs(&mut certs_file)
+      .collect::<Result<Vec<_>, _>>()
+      .unwrap();
+    let tls_key = rustls_pemfile::pkcs8_private_keys(&mut key_file)
+      .next()
+      .unwrap()
+      .unwrap();
 
-  // set up TLS config options
-  let tls_config = rustls::ServerConfig::builder()
-    .with_no_client_auth()
-    .with_single_cert(tls_certs, rustls::pki_types::PrivateKeyDer::Pkcs8(tls_key))
-    .unwrap();
+    // set up TLS config options
+    Some(
+      rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(tls_certs, rustls::pki_types::PrivateKeyDer::Pkcs8(tls_key))
+        .unwrap(),
+    )
+  } else {
+    None
+  };
 
   let server = HttpServer::new(move || {
     let cors = Cors::default()
@@ -65,7 +71,12 @@ async fn main() -> std::io::Result<()> {
   });
 
   match tls_enabled {
-    true => server.bind_rustls_0_23(addr, tls_config)?.run().await,
+    true => {
+      server
+        .bind_rustls_0_23(addr, tls_config.unwrap())?
+        .run()
+        .await
+    }
     false => server.bind(addr)?.run().await,
   }
 }

--- a/src/models/materialized_views/settings_by_username.rs
+++ b/src/models/materialized_views/settings_by_username.rs
@@ -1,12 +1,14 @@
 use charybdis::macros::charybdis_view_model;
-use charybdis::types::{Int, Text, Timestamp};
+use charybdis::types::{Frozen, Int, Text, Timestamp};
 use serde::{Deserialize, Serialize};
 
+use crate::models::settings::SettingOptions;
+
 #[charybdis_view_model(
-    table_name=settings_by_username,
-    base_table=settings,
-    partition_keys=[username],
-    clustering_keys=[user_id, updated_at],
+    table_name = settings_by_username,
+    base_table = settings,
+    partition_keys = [username],
+    clustering_keys = [user_id, updated_at],
     table_options = "
      CLUSTERING ORDER BY (updated_at DESC, user_id DESC)
     "
@@ -17,7 +19,7 @@ pub struct SettingsByUsername {
   pub username: Text,
   pub locale: Option<Text>,
   pub timezone: Option<Text>,
-  pub occupation: Option<Text>,
-  pub pronouns: Option<Text>,
+  pub occupation: Frozen<SettingOptions>,
+  pub pronouns: Frozen<SettingOptions>,
   pub updated_at: Timestamp,
 }

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -1,7 +1,15 @@
-use charybdis::macros::charybdis_model;
-use charybdis::types::{Int, Text, Timestamp};
+use charybdis::macros::{charybdis_model, charybdis_udt_model};
+use charybdis::types::{Frozen, Int, Text, Timestamp};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+#[charybdis_udt_model(type_name = settingoptions)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct SettingOptions {
+  pub name: Text,
+  pub slug: Text,
+  pub translation_key: Text,
+}
 
 #[charybdis_model(
     table_name = settings,
@@ -20,8 +28,8 @@ pub struct Settings {
   pub username: Option<Text>,
   pub locale: Option<Text>,
   pub timezone: Option<Text>,
-  pub occupation: Option<Text>,
-  pub pronouns: Option<Text>,
+  pub occupation: Frozen<SettingOptions>,
+  pub pronouns: Frozen<SettingOptions>,
   #[serde(default = "default_updated_at")]
   pub updated_at: Timestamp,
 }


### PR DESCRIPTION
## Motivation

Our database is growing sporadically and for that we need to think about micro operations that would be happening on the user side. 

Instead we go for an Wide Column representation, we can start by using UDT's (User Defined Types) which ScyllaDB provides to make it work.

The new modeling:
```cql
CREATE TYPE twitch.settingoptions (
    name text,
    slug text,
    translation_key text
);

CREATE TABLE twitch.settings (
    user_id int,
    updated_at timestamp,
    locale text,
    occupation frozen<settingoptions>,
    pronouns frozen<settingoptions>,
    timezone text,
    username text,
    PRIMARY KEY (user_id, updated_at)
);

```
Querying with CQLsh: 
```
select user_id, username, occupation, pronouns from settings;

 user_id | username    | occupation                                                  | pronouns
---------+-------------+-------------------------------------------------------------+------------------------------------------------------------
     123 | danielhe4rt | {name: 'fodase', slug: 'fodase', translation_key: 'fodase'} | {name: 'He/Him', slug: 'he-him', translation_key: 'HeHim'}
```

The request response from `/settings/{username}`: 
```json
{
    "locale": "en-US",
    "occupation": {
        "name": "fodase",
        "slug": "fodase",
        "translation_key": "fodase"
    },
    "pronouns": {
        "name": "He/Him",
        "slug": "he-him",
        "translation_key": "HeHim"
    },
    "timezone": null,
    "updated_at": "2024-08-11T22:02:38.841Z",
    "user_id": 123,
    "username": "danielhe4rt"
}
```