### PR TITLE
feat: sync colors and effects 

### DIFF
--- a/current_schema.json
+++ b/current_schema.json
@@ -1,158 +1,17 @@
 {
   "tables": {
-    "settings": {
-      "fields": [
-        [
-          "locale",
-          "text",
-          false
-        ],
-        [
-          "occupation",
-          "text",
-          false
-        ],
-        [
-          "pronouns",
-          "text",
-          false
-        ],
-        [
-          "timezone",
-          "text",
-          false
-        ],
-        [
-          "updated_at",
-          "timestamp",
-          false
-        ],
-        [
-          "user_id",
-          "int",
-          false
-        ],
-        [
-          "username",
-          "text",
-          false
-        ]
-      ],
-      "field_names": [
-        "occupation",
-        "updated_at",
-        "user_id",
-        "username",
-        "locale",
-        "timezone",
-        "pronouns"
-      ],
-      "types_by_name": {
-        "locale": "text",
-        "updated_at": "timestamp",
-        "pronouns": "text",
-        "occupation": "text",
-        "username": "text",
-        "timezone": "text",
-        "user_id": "int"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "user_id"
-      ],
-      "clustering_keys": [
-        "updated_at"
-      ],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
-    "user_metrics_by_channel_v1": {
-      "fields": [
-        [
-          "channel_id",
-          "text",
-          false
-        ],
-        [
-          "messages_count",
-          "counter",
-          false
-        ],
-        [
-          "minutes_watched",
-          "counter",
-          false
-        ],
-        [
-          "user_id",
-          "int",
-          false
-        ]
-      ],
-      "field_names": [
-        "minutes_watched",
-        "channel_id",
-        "messages_count",
-        "user_id"
-      ],
-      "types_by_name": {
-        "channel_id": "text",
-        "messages_count": "counter",
-        "minutes_watched": "counter",
-        "user_id": "int"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "channel_id",
-        "user_id"
-      ],
-      "clustering_keys": [],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
-    "user_tokens_v1": {
-      "fields": [
-        [
-          "access_token",
-          "text",
-          false
-        ],
-        [
-          "user_id",
-          "int",
-          false
-        ]
-      ],
-      "field_names": [
-        "access_token",
-        "user_id"
-      ],
-      "types_by_name": {
-        "user_id": "int",
-        "access_token": "text"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "access_token"
-      ],
-      "clustering_keys": [],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
     "settings_v1": {
       "fields": [
+        [
+          "color",
+          "frozen<coloroption>",
+          false
+        ],
+        [
+          "effect",
+          "frozen<effectoption>",
+          false
+        ],
         [
           "is_developer",
           "boolean",
@@ -195,64 +54,28 @@
         ]
       ],
       "field_names": [
-        "user_id",
-        "pronouns",
-        "updated_at",
-        "username",
         "locale",
-        "timezone",
+        "updated_at",
+        "color",
         "is_developer",
-        "occupation"
+        "user_id",
+        "username",
+        "effect",
+        "occupation",
+        "timezone",
+        "pronouns"
       ],
       "types_by_name": {
+        "pronouns": "frozen<settingoptions>",
+        "updated_at": "timestamp",
+        "is_developer": "boolean",
+        "timezone": "text",
+        "effect": "frozen<effectoption>",
+        "color": "frozen<coloroption>",
+        "locale": "text",
         "occupation": "frozen<settingoptions>",
         "username": "text",
-        "is_developer": "boolean",
-        "updated_at": "timestamp",
-        "pronouns": "frozen<settingoptions>",
-        "timezone": "text",
-        "locale": "text",
         "user_id": "int"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "user_id"
-      ],
-      "clustering_keys": [],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
-    "user_metrics_v1": {
-      "fields": [
-        [
-          "messages_count",
-          "counter",
-          false
-        ],
-        [
-          "minutes_watched",
-          "counter",
-          false
-        ],
-        [
-          "user_id",
-          "int",
-          false
-        ]
-      ],
-      "field_names": [
-        "minutes_watched",
-        "user_id",
-        "messages_count"
-      ],
-      "types_by_name": {
-        "user_id": "int",
-        "messages_count": "counter",
-        "minutes_watched": "counter"
       },
       "type_name": "",
       "table_name": "",
@@ -292,14 +115,14 @@
       "field_names": [
         "messages_count",
         "category_id",
-        "user_id",
-        "minutes_watched"
+        "minutes_watched",
+        "user_id"
       ],
       "types_by_name": {
-        "messages_count": "counter",
+        "category_id": "text",
         "minutes_watched": "counter",
-        "user_id": "int",
-        "category_id": "text"
+        "messages_count": "counter",
+        "user_id": "int"
       },
       "type_name": "",
       "table_name": "",
@@ -338,9 +161,9 @@
         "minutes_watched"
       ],
       "types_by_name": {
-        "user_id": "int",
+        "minutes_watched": "int",
         "category_id": "text",
-        "minutes_watched": "int"
+        "user_id": "int"
       },
       "type_name": "",
       "table_name": "",
@@ -352,6 +175,149 @@
         "category_id",
         "minutes_watched"
       ],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "settings": {
+      "fields": [
+        [
+          "locale",
+          "text",
+          false
+        ],
+        [
+          "occupation",
+          "text",
+          false
+        ],
+        [
+          "pronouns",
+          "text",
+          false
+        ],
+        [
+          "timezone",
+          "text",
+          false
+        ],
+        [
+          "updated_at",
+          "timestamp",
+          false
+        ],
+        [
+          "user_id",
+          "int",
+          false
+        ],
+        [
+          "username",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "pronouns",
+        "occupation",
+        "timezone",
+        "user_id",
+        "username",
+        "updated_at",
+        "locale"
+      ],
+      "types_by_name": {
+        "user_id": "int",
+        "locale": "text",
+        "username": "text",
+        "pronouns": "text",
+        "occupation": "text",
+        "timezone": "text",
+        "updated_at": "timestamp"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "user_id"
+      ],
+      "clustering_keys": [
+        "updated_at"
+      ],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "user_tokens_v1": {
+      "fields": [
+        [
+          "access_token",
+          "text",
+          false
+        ],
+        [
+          "user_id",
+          "int",
+          false
+        ]
+      ],
+      "field_names": [
+        "user_id",
+        "access_token"
+      ],
+      "types_by_name": {
+        "access_token": "text",
+        "user_id": "int"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "access_token"
+      ],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "user_metrics_v1": {
+      "fields": [
+        [
+          "messages_count",
+          "counter",
+          false
+        ],
+        [
+          "minutes_watched",
+          "counter",
+          false
+        ],
+        [
+          "user_id",
+          "int",
+          false
+        ]
+      ],
+      "field_names": [
+        "messages_count",
+        "minutes_watched",
+        "user_id"
+      ],
+      "types_by_name": {
+        "user_id": "int",
+        "minutes_watched": "counter",
+        "messages_count": "counter"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "user_id"
+      ],
+      "clustering_keys": [],
       "static_columns": [],
       "global_secondary_indexes": [],
       "local_secondary_indexes": [],
@@ -376,14 +342,14 @@
         ]
       ],
       "field_names": [
-        "channel_id",
+        "minutes_watched",
         "user_id",
-        "minutes_watched"
+        "channel_id"
       ],
       "types_by_name": {
-        "channel_id": "text",
         "minutes_watched": "int",
-        "user_id": "int"
+        "user_id": "int",
+        "channel_id": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -424,16 +390,16 @@
         ]
       ],
       "field_names": [
-        "content",
-        "uri",
         "updated_at",
+        "uri",
+        "content",
         "user_id"
       ],
       "types_by_name": {
         "updated_at": "timestamp",
-        "user_id": "int",
         "content": "text",
-        "uri": "text"
+        "uri": "text",
+        "user_id": "int"
       },
       "type_name": "",
       "table_name": "",
@@ -450,9 +416,154 @@
       "global_secondary_indexes": [],
       "local_secondary_indexes": [],
       "table_options": null
+    },
+    "user_metrics_by_channel_v1": {
+      "fields": [
+        [
+          "channel_id",
+          "text",
+          false
+        ],
+        [
+          "messages_count",
+          "counter",
+          false
+        ],
+        [
+          "minutes_watched",
+          "counter",
+          false
+        ],
+        [
+          "user_id",
+          "int",
+          false
+        ]
+      ],
+      "field_names": [
+        "channel_id",
+        "messages_count",
+        "user_id",
+        "minutes_watched"
+      ],
+      "types_by_name": {
+        "channel_id": "text",
+        "user_id": "int",
+        "minutes_watched": "counter",
+        "messages_count": "counter"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "channel_id",
+        "user_id"
+      ],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
     }
   },
   "udts": {
+    "effectoption": {
+      "fields": [
+        [
+          "name",
+          "text",
+          false
+        ],
+        [
+          "slug",
+          "text",
+          false
+        ],
+        [
+          "translation_key",
+          "text",
+          false
+        ],
+        [
+          "class_name",
+          "text",
+          false
+        ],
+        [
+          "hex",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "translation_key",
+        "class_name",
+        "hex",
+        "name",
+        "slug"
+      ],
+      "types_by_name": {
+        "slug": "text",
+        "hex": "text",
+        "name": "text",
+        "translation_key": "text",
+        "class_name": "text"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "coloroption": {
+      "fields": [
+        [
+          "name",
+          "text",
+          false
+        ],
+        [
+          "slug",
+          "text",
+          false
+        ],
+        [
+          "translation_key",
+          "text",
+          false
+        ],
+        [
+          "hex",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "translation_key",
+        "slug",
+        "name",
+        "hex"
+      ],
+      "types_by_name": {
+        "name": "text",
+        "slug": "text",
+        "translation_key": "text",
+        "hex": "text"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
     "settingoptions": {
       "fields": [
         [
@@ -472,14 +583,14 @@
         ]
       ],
       "field_names": [
+        "slug",
         "name",
-        "translation_key",
-        "slug"
+        "translation_key"
       ],
       "types_by_name": {
-        "translation_key": "text",
         "slug": "text",
-        "name": "text"
+        "name": "text",
+        "translation_key": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -532,22 +643,22 @@
         ]
       ],
       "field_names": [
-        "timezone",
-        "updated_at",
-        "username",
         "occupation",
+        "timezone",
         "user_id",
-        "pronouns",
-        "locale"
+        "locale",
+        "username",
+        "updated_at",
+        "pronouns"
       ],
       "types_by_name": {
-        "locale": "text",
-        "occupation": "text",
-        "updated_at": "timestamp",
-        "timezone": "text",
-        "username": "text",
         "user_id": "int",
-        "pronouns": "text"
+        "updated_at": "timestamp",
+        "locale": "text",
+        "pronouns": "text",
+        "username": "text",
+        "occupation": "text",
+        "timezone": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -566,6 +677,16 @@
     },
     "settings_by_username_v1": {
       "fields": [
+        [
+          "color",
+          "frozen<coloroption>",
+          false
+        ],
+        [
+          "effect",
+          "frozen<effectoption>",
+          false
+        ],
         [
           "locale",
           "text",
@@ -603,22 +724,26 @@
         ]
       ],
       "field_names": [
+        "pronouns",
+        "username",
         "locale",
         "updated_at",
+        "user_id",
+        "effect",
+        "color",
         "timezone",
-        "username",
-        "occupation",
-        "pronouns",
-        "user_id"
+        "occupation"
       ],
       "types_by_name": {
+        "timezone": "text",
         "occupation": "frozen<settingoptions>",
         "locale": "text",
         "updated_at": "timestamp",
-        "username": "text",
+        "pronouns": "frozen<settingoptions>",
+        "color": "frozen<coloroption>",
+        "effect": "frozen<effectoption>",
         "user_id": "int",
-        "timezone": "text",
-        "pronouns": "frozen<settingoptions>"
+        "username": "text"
       },
       "type_name": "",
       "table_name": "",

--- a/src/models/v1/settings.rs
+++ b/src/models/v1/settings.rs
@@ -11,6 +11,25 @@ pub struct SettingOptions {
   pub translation_key: Text,
 }
 
+#[charybdis_udt_model(type_name = coloroption)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct ColorOption {
+    pub name: Text,
+    pub slug: Text,
+    pub translation_key: Text,
+    pub hex: Option<Text>,
+}
+
+#[charybdis_udt_model(type_name = effectoption)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct EffectOption {
+    pub name: Text,
+    pub slug: Text,
+    pub translation_key: Text,
+    pub class_name: Text,
+    pub hex: Option<Text>,
+}
+
 #[charybdis_model(
     table_name = settings_v1,
     partition_keys = [user_id],
@@ -27,6 +46,8 @@ pub struct Settings {
   pub timezone: Option<Text>,
   pub occupation: Frozen<SettingOptions>,
   pub pronouns: Frozen<SettingOptions>,
+  pub color: Frozen<ColorOption>,
+  pub effect: Frozen<EffectOption>,
   pub is_developer: Option<Boolean>,
   #[serde(default = "default_updated_at")]
   pub updated_at: Timestamp,

--- a/src/models/v1/settings.rs
+++ b/src/models/v1/settings.rs
@@ -14,20 +14,20 @@ pub struct SettingOptions {
 #[charybdis_udt_model(type_name = coloroption)]
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct ColorOption {
-    pub name: Text,
-    pub slug: Text,
-    pub translation_key: Text,
-    pub hex: Option<Text>,
+  pub name: Text,
+  pub slug: Text,
+  pub translation_key: Text,
+  pub hex: Option<Text>,
 }
 
 #[charybdis_udt_model(type_name = effectoption)]
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct EffectOption {
-    pub name: Text,
-    pub slug: Text,
-    pub translation_key: Text,
-    pub class_name: Text,
-    pub hex: Option<Text>,
+  pub name: Text,
+  pub slug: Text,
+  pub translation_key: Text,
+  pub class_name: Text,
+  pub hex: Option<Text>,
 }
 
 #[charybdis_model(

--- a/src/models/v1/settings_by_username.rs
+++ b/src/models/v1/settings_by_username.rs
@@ -17,7 +17,7 @@ pub struct SettingsByUsername {
   pub timezone: Option<Text>,
   pub occupation: Frozen<SettingOptions>,
   pub pronouns: Frozen<SettingOptions>,
-    pub color: Frozen<ColorOption>,
-    pub effect: Frozen<EffectOption>,
+  pub color: Frozen<ColorOption>,
+  pub effect: Frozen<EffectOption>,
   pub updated_at: Timestamp,
 }

--- a/src/models/v1/settings_by_username.rs
+++ b/src/models/v1/settings_by_username.rs
@@ -1,4 +1,4 @@
-use crate::models::v1::settings::SettingOptions;
+use crate::models::v1::settings::{ColorOption, EffectOption, SettingOptions};
 use charybdis::macros::charybdis_view_model;
 use charybdis::types::{Frozen, Int, Text, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -17,5 +17,7 @@ pub struct SettingsByUsername {
   pub timezone: Option<Text>,
   pub occupation: Frozen<SettingOptions>,
   pub pronouns: Frozen<SettingOptions>,
+    pub color: Frozen<ColorOption>,
+    pub effect: Frozen<EffectOption>,
   pub updated_at: Timestamp,
 }


### PR DESCRIPTION
## Motivation

As discussed at "https://github.com/basementdevs/twitch-better-profile/issues/60", all the related colors or effects would be synced in new UDT (User Defined Types). Either `settings_v1` than `settings_by_username_v1` got updated with the new fields.

```cql
/** New types */
CREATE TYPE twitch.color_option (
    name text,
    slug text,
    translation_key text,
    hex text,
);

/** New types */
CREATE TYPE twitch.effect_option (
    name text,
    slug text,
    translation_key text,
    class: text
    hex text,
);

CREATE TABLE twitch.settings_v1 (
    user_id int,
    is_developer boolean,
    locale text,
    color: frozen<color_option>,
    effect: frozen<effect_option>,
    occupation frozen<settingoptions>,
    pronouns frozen<settingoptions>,
    timezone text,
    updated_at timestamp,
    username text,
    PRIMARY KEY (user_id)
) 
```